### PR TITLE
[WIP]: Add salmon splice indices to Refgenie

### DIFF
--- a/envs/refgenie.yml
+++ b/envs/refgenie.yml
@@ -2,7 +2,8 @@ name: refgenie
 dependencies:
   - refgenie=0.12.0
   - samtools
-  - salmon=1.5.1
+  - salmon=1.9.0
   - kallisto=0.46.2
   - hisat2=2.1.0
   - bowtie2=2.3.2
+  - pyroe


### PR DESCRIPTION
In order to use alevin-fry in the quantification pipeline for droplet snRNA and scRNA-seq we need  salmon 'splici' (spliced transcripts + introns) indices.

For that we need to:

- Create splici transcriptome
- Update the version of salmon we currently use to build indices

