### PR TITLE
Add salmon splici indices to Refgenie

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This workflow is designed to copy all of the base genome resources used by the g
 
 ```
 nextflow run isl_refs_to_refgenie/main.nf \
-    --mode=<type of salmon index: [normal, splici]>
+    --mode=<type of salmon index: [normal, splici]> \
     --irapConfigDir=<path to directory with species-wise configuration files as used by IRAP> \
     --irapDataDir=<path to top level IRAP data directory, with 'references' subdirectory> \
     --refgenieDir=<path to refgenie top directory> \

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This workflow is designed to copy all of the base genome resources used by the g
 
 ```
 nextflow run isl_refs_to_refgenie/main.nf \
+    --mode=<type of salmon index: [normal, splici]>
     --irapConfigDir=<path to directory with species-wise configuration files as used by IRAP> \
     --irapDataDir=<path to top level IRAP data directory, with 'references' subdirectory> \
     --refgenieDir=<path to refgenie top directory> \
     --islGenomes=<path togenome_references.conf>
-    --mode=<type of salmon index: [normal, splici]>
 ```
 
 ## What's done

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This workflow is designed to copy all of the base genome resources used by the g
 
 ```
 nextflow run isl_refs_to_refgenie/main.nf \
-    --mode=<type of salmon index: [normal, splici]> \
+    --mode=<type of salmon index: [normal, splici, both]> \
     --irapConfigDir=<path to directory with species-wise configuration files as used by IRAP> \
     --irapDataDir=<path to top level IRAP data directory, with 'references' subdirectory> \
     --refgenieDir=<path to refgenie top directory> \
@@ -44,7 +44,7 @@ All genome resources are indexed by hisat2. Contamination indices are also index
 #### Transcriptome indices
 
 Each of the 4 transcriptome assets for each species (current and newest, with/without spikes) is indexed by both Kallisto and Salmon, with versions picked to match our single-cell pipelines.
-The Salmon indices can be eiher build with the cDNA ('normal') or an intron containing transcriptome can be indexed ('splici').
+The Salmon indices can be eiher build with the cDNA ('normal') or an intron containing transcriptome can be indexed ('splici'). When running with --mode both, both normal and splici salmon index are generated. 
 
 ## Result
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ nextflow run isl_refs_to_refgenie/main.nf \
     --irapDataDir=<path to top level IRAP data directory, with 'references' subdirectory> \
     --refgenieDir=<path to refgenie top directory> \
     --islGenomes=<path togenome_references.conf>
+    --mode=<type of salmon index: [normal, splici]>
 ```
 
 ## What's done
@@ -34,7 +35,7 @@ Input files are discovered for each species:
 
 ### Building Refgenie assets
 
-The plain base genome FASTA is used as the root asset for an assembly. All others (cDNAs, GTFs etc) are sub-assets of that. Genomes, transcriptomes and GTFs are also combined with spike-ins (currently just ERCC) and built/indexed under a separate root asset.
+The plain base genome FASTA is used as the root asset for an assembly. All others (cDNAs, GTFs etc) are sub-assets of that. Genomes, transcriptomes and GTFs are also combined with spike-ins (currently just ERCC) and built/indexed under a separate root asset. The intron-containing splici transcriptome asset is build with ```pyroe make-splici``` from the genome FASTA.
 
 ### Genome indices
 
@@ -43,6 +44,7 @@ All genome resources are indexed by hisat2. Contamination indices are also index
 #### Transcriptome indices
 
 Each of the 4 transcriptome assets for each species (current and newest, with/without spikes) is indexed by both Kallisto and Salmon, with versions picked to match our single-cell pipelines.
+The Salmon indices can be eiher build with the cDNA ('normal') or an intron containing transcriptome can be indexed ('splici').
 
 ## Result
 

--- a/bin/build_asset.sh
+++ b/bin/build_asset.sh
@@ -72,7 +72,7 @@ fi
 built=0
 firsttag=
 
-if [ -n "$refenieDir" ]; then
+if [ -n "$refgenieDir" ]; then
     export REFGENIE=${refgenieDir}/genome_config.yaml 
 elif [ -n "$REFGENIE" ]; then
     refgenieDir=$(dirname $REFGENIE)

--- a/envs/refgenie.yml
+++ b/envs/refgenie.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - refgenie=0.12.0
   - samtools
-  - salmon=1.9.0
+  - salmon=1.7.0
   - kallisto=0.48.0
   - hisat2=2.2.1
   - bowtie2=2.4.5

--- a/envs/refgenie.yml
+++ b/envs/refgenie.yml
@@ -7,7 +7,7 @@ dependencies:
   - refgenie=0.12.0
   - samtools
   - salmon=1.7.0
-  - kallisto=0.48.0
+  - kallisto=0.46.2
   - hisat2=2.2.1
   - bowtie2=2.4.5
   - pyroe

--- a/envs/refgenie.yml
+++ b/envs/refgenie.yml
@@ -3,7 +3,7 @@ dependencies:
   - refgenie=0.12.0
   - samtools
   - salmon=1.9.0
-  - kallisto=0.46.2
-  - hisat2=2.1.0
-  - bowtie2=2.3.2
+  - kallisto=0.48.0
+  - hisat2=2.2.1
+  - bowtie2=2.4.5
   - pyroe

--- a/envs/refgenie.yml
+++ b/envs/refgenie.yml
@@ -2,7 +2,8 @@ name: refgenie
 dependencies:
   - refgenie=0.12.0
   - samtools
-  - salmon=1.5.1
+  - salmon=1.9.0
   - kallisto=0.46.2
   - hisat2=2.1.0
   - bowtie2=2.3.2
+  - pyroe

--- a/envs/refgenie.yml
+++ b/envs/refgenie.yml
@@ -10,4 +10,4 @@ dependencies:
   - kallisto=0.46.2
   - hisat2=2.2.1
   - bowtie2=2.4.5
-  - pyroe
+  - pyroe=0.6.2

--- a/envs/refgenie.yml
+++ b/envs/refgenie.yml
@@ -1,4 +1,8 @@
 name: refgenie
+channels:
+  - conda-forge
+  - bioconda
+  - default
 dependencies:
   - refgenie=0.12.0
   - samtools

--- a/main.nf
+++ b/main.nf
@@ -551,6 +551,7 @@ process build_salmon_index {
                 echo "\${at}--salmon_v\${salmon_version}"
         done | tr '\\n' ',' | sed 's/,\$//')  
         build_asset.sh \
+         -a ${species}--${assembly} \
          -r salmon_index \
          -d ${params.refgenieDir} \
          -t \$tags \

--- a/main.nf
+++ b/main.nf
@@ -400,7 +400,7 @@ SPLICI_REFERENCE
     
 CDNA_REFERENCE_FOR_SALMON
    .join( SPLICI_REFERENCE_FOR_SALMON)
-   .into {
+   .set {
       REFERENCE_FOR_SALMON
       }
 
@@ -541,7 +541,7 @@ process build_salmon_index {
     input:
         val(reduced) from REDUCED_SPLICI
         val(reduced) from REDUCED_CDNAS
-        tuple val(species), val(assembly), val(version), val(additionalTags) from SPLICI_REFERENCE
+        tuple val(species), val(assembly), val(version), val(additionalTags) from REFERENCE_FOR_SALMON
 
     output:
         tuple val(species), val(assembly), val(version) into SALMON_DONE

--- a/main.nf
+++ b/main.nf
@@ -202,6 +202,7 @@ REF_FILES_FOR_GENOME
     .into{
         GENOME_ALIAS_INPUTS
         GENOME_BUILD_INPUTS
+        SPLICI_BUILD_INPUTS
     }
 
 process build_genome {

--- a/main.nf
+++ b/main.nf
@@ -564,10 +564,10 @@ process build_salmon_index {
         """
         salmon_version=\$(cat ${baseDir}/envs/refgenie.yml | grep salmon | awk -F'=' '{print \$2}')
         splici_asset="fasta=${species}--${assembly}/fasta_txome:splici_${version}"
-    
+        
         # Append the salmon version to all the input tags
         tags=\$(for at in \$(echo ${version} ${additionalTags} | tr "," "\\n"); do
-                echo "\${at}--salmon_v\${salmon_version}"
+                 echo "\${at}--salmon_v\${salmon_version}"
         done | tr '\\n' ',' | sed 's/,\$//')  
         build_asset.sh \
         -a ${species}--${assembly} \

--- a/main.nf
+++ b/main.nf
@@ -351,7 +351,7 @@ process reduce_cdnas {
     """ 
 }
 
-\\ build a assets for splici trancritome
+// build a assets for splici trancritome
 
 process build_splici_txome {
  

--- a/main.nf
+++ b/main.nf
@@ -351,7 +351,7 @@ process reduce_cdnas {
     """ 
 }
 
-# build a assets for splici trancritome
+\\ build a assets for splici trancritome
 
 process build_splici_txome {
  

--- a/main.nf
+++ b/main.nf
@@ -363,7 +363,7 @@ process build_splici_txome {
 
     input:
         val(reduced) from REDUCED_REFERENCES
-        tuple val(species), val(assembly), file(filePath), val(additionalTag_genome), val(version), file(gtf), val(additionalTags) from SPLICI_BUILD_INPUTS.join( GTF_SPLICI_BUILD_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[5], r[6])}, by: [0, 1])
+        tuple val(species), val(assembly), file(filePath), val(additionalTag_genome), val(version), file(gtf), val(additionalTags) from SPLICI_BUILD_INPUTS.join( GTF_SPLICI_BUILD_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[5], r[6])}, by: [0, 1], remainder: true)
        
     output:
         tuple val(species), val(assembly), val(version), val(additionalTags) into SPLICI_REFERENCE

--- a/main.nf
+++ b/main.nf
@@ -1,6 +1,6 @@
 #!/usr/bin/env nextflow
 
-// mode parameter defines if normal or splici salmon index is build
+// mode parameter defines if normal and/or splici salmon index is build
 mode = params.mode
 
 // IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf").filter{it.baseName == 'drosophila_melanogaster'}
@@ -547,7 +547,7 @@ process build_salmon_index {
         tuple val(species), val(assembly), val(version) into SALMON_DONE
         
     script:
-    if( mode == 'normal' )
+    if( mode == 'normal' || mode == 'both' )
         """
         salmon_version=\$(cat ${baseDir}/envs/refgenie.yml | grep salmon | awk -F'=' '{print \$2}')
         cdna_asset="fasta=${species}--${assembly}/fasta_txome:cdna_${version}"
@@ -566,7 +566,7 @@ process build_salmon_index {
          -b true \
          -s \$cdna_asset
         """
-    else if( mode == 'splici' )
+    if( mode == 'splici' || mode == 'both' )
         """
         salmon_version=\$(cat ${baseDir}/envs/refgenie.yml | grep salmon | awk -F'=' '{print \$2}')
         splici_asset="fasta=${species}--${assembly}/fasta_txome:splici_${version}"

--- a/main.nf
+++ b/main.nf
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
-//IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf").filter{it.baseName == 'mus_musculus'}
-IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf")
+IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf").filter{it.baseName == 'drosophila_melanogaster'}
+// IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf")
 SPIKES_GENOME = Channel.fromPath( "${baseDir}/spikes/*/*.fa.gz" ).filter { !it.toString().contains('transcript') }.map{r -> tuple(r.toString().split('/')[-2], r)}
 SPIKES_CDNA = Channel.fromPath( "${baseDir}/spikes/*/*.transcripts.fa.gz" ).map{r -> tuple(r.toString().split('/')[-2], r)}
 SPIKES_GTF = Channel.fromPath( "${baseDir}/spikes/*/*.gtf.gz" ).filter  { !it.toString().contains('transcript') }.map{r -> tuple(r.toString().split('/')[-2], r)}
@@ -363,7 +363,7 @@ process build_splici_txome {
 
     input:
         val(reduced) from REDUCED_REFERENCES
-        tuple val(species), val(assembly), file(filePath), val(additionalTag_genome), val(version), file(gtf), val(additionalTags) from SPLICI_BUILD_INPUTS.join( GTF_SPLICI_BUILD_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[5], r[6])}, by: [0, 1], remainder: true)
+        tuple val(species), val(assembly), file(filePath), val(additionalTag_genome), val(version), file(gtf), val(additionalTags) from SPLICI_BUILD_INPUTS.combine( GTF_SPLICI_BUILD_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[5], r[6])}, by: [0, 1])
        
     output:
         tuple val(species), val(assembly), val(version), val(additionalTags) into SPLICI_REFERENCE

--- a/main.nf
+++ b/main.nf
@@ -364,7 +364,7 @@ process build_splici_txome {
     input:
         val(reduced) from REDUCED_REFERENCES
         tuple val(species), val(assembly), file(filePath), val(additionalTag) from SPLICI_BUILD_INPUTS        
-        tuple val(species), val(assembly), val(version), val(gtf), val(additionalTags) from GTF_SPLICI_BUILD_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[5], r[6])}
+        tuple val(species), val(assembly), val(version), file(gtf), val(additionalTags) from GTF_SPLICI_BUILD_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[5], r[6])}
 
        
     output:

--- a/main.nf
+++ b/main.nf
@@ -396,7 +396,13 @@ SPLICI_REFERENCE
         SPLICI_REFERENCE_FOR_COLLECTION
         SPLICI_REFERENCE_FOR_SALMON
     }
-
+    
+    
+CDNA_REFERENCE_FOR_SALMON
+   .join( SPLICI_REFERENCE_FOR_SALMON)
+   .into {
+      REFERENCE_FOR_SALMON
+      }
 
 SPLICI_REFERENCE_FOR_COLLECTION
     .collect()
@@ -535,7 +541,7 @@ process build_salmon_index {
     input:
         val(reduced) from REDUCED_SPLICI
         val(reduced) from REDUCED_CDNAS
-        tuple val(species), val(assembly), val(version), val(additionalTags) from SPLICI_REFERENCE_FOR_SALMON.join(CDNA_REFERENCE_FOR_SALMON)
+        tuple val(species), val(assembly), val(version), val(additionalTags) from SPLICI_REFERENCE
 
     output:
         tuple val(species), val(assembly), val(version) into SALMON_DONE

--- a/main.nf
+++ b/main.nf
@@ -534,6 +534,7 @@ process build_salmon_index {
 
     input:
         val(reduced) from REDUCED_SPLICI
+        val(reduced) from REDUCED_CDNAS
         tuple val(species), val(assembly), val(version), val(additionalTags) from SPLICI_REFERENCE_FOR_SALMON
 
     output:

--- a/main.nf
+++ b/main.nf
@@ -535,7 +535,7 @@ process build_salmon_index {
     input:
         val(reduced) from REDUCED_SPLICI
         val(reduced) from REDUCED_CDNAS
-        tuple val(species), val(assembly), val(version), val(additionalTags) from SPLICI_REFERENCE_FOR_SALMON
+        tuple val(species), val(assembly), val(version), val(additionalTags) from SPLICI_REFERENCE_FOR_SALMON.join(CDNA_REFERENCE_FOR_SALMON)
 
     output:
         tuple val(species), val(assembly), val(version) into SALMON_DONE

--- a/main.nf
+++ b/main.nf
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
-IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf").filter{it.baseName == 'drosophila_melanogaster'}
-// IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf")
+// IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf").filter{it.baseName == 'drosophila_melanogaster'}
+IRAP_CONFIGS = Channel.fromPath( "${params.irapConfigDir}/*.conf")
 SPIKES_GENOME = Channel.fromPath( "${baseDir}/spikes/*/*.fa.gz" ).filter { !it.toString().contains('transcript') }.map{r -> tuple(r.toString().split('/')[-2], r)}
 SPIKES_CDNA = Channel.fromPath( "${baseDir}/spikes/*/*.transcripts.fa.gz" ).map{r -> tuple(r.toString().split('/')[-2], r)}
 SPIKES_GTF = Channel.fromPath( "${baseDir}/spikes/*/*.gtf.gz" ).filter  { !it.toString().contains('transcript') }.map{r -> tuple(r.toString().split('/')[-2], r)}

--- a/main.nf
+++ b/main.nf
@@ -363,9 +363,7 @@ process build_splici_txome {
 
     input:
         val(reduced) from REDUCED_REFERENCES
-        tuple val(species), val(assembly), file(filePath), val(additionalTag) from SPLICI_BUILD_INPUTS        
-        tuple val(species), val(assembly), val(version), file(gtf), val(additionalTags) from GTF_SPLICI_BUILD_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[5], r[6])}
-
+        tuple val(species), val(assembly), file(filePath), val(additionalTag_genome), val(version), file(gtf), val(additionalTags) from SPLICI_BUILD_INPUTS.join( GTF_SPLICI_BUILD_INPUTS.map{r -> tuple(r[0], r[1], r[2], r[5], r[6])}, by: [0, 1])
        
     output:
         tuple val(species), val(assembly), val(version), val(additionalTags) into SPLICI_REFERENCE


### PR DESCRIPTION
In order to use alevin-fry in the quantification pipeline for droplet snRNA and scRNA-seq we need salmon 'splici' (spliced transcripts + introns) indices.

For that we need to:

- Create assets for splici transcriptomes

- build indices from splici transcriptome with recent version of salmon